### PR TITLE
修复<p>无法被替换；

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -117,7 +117,7 @@ class Converter
         }, $result);
 
         foreach ($this->htmlTags as $k => $v) {
-            $result = preg_replace('/<'.$k.'\s+([^>]*?)>(.*?)\<\/'.$k.'>/is', '<'.$v.' $1 data-htmltag="'.$k.'">$2</'.$v.'>', $result);
+            $result = preg_replace('/<'.$k.'\s{0,}([^>]*?)>(.*?)\<\/'.$k.'>/is', '<'.$v.' $1 data-htmltag="'.$k.'">$2</'.$v.'>', $result);
         }
 
         return $result;


### PR DESCRIPTION
```
<p>作为一个普通人，我们读书、工作的愿望，离不开未来的“前途”和“钱途”。但老板不会平白无故给你升职加薪，关键还是得靠自己，考证是升职加薪的一个可行方法。以下10个证书很有含金量，想要考证的童鞋可以考虑哦。</p>
```
如何开始字符只是<p>则无法被替换；
如果是<p style="">等，则可以被替换；

修复方式：将+改为了{0,}，经测试是可行的